### PR TITLE
feat: add CRUD operations for channels

### DIFF
--- a/src/config/apollo.ts
+++ b/src/config/apollo.ts
@@ -3,7 +3,9 @@ import { expressMiddleware } from "@apollo/server/express4";
 import { Express } from "express";
 import { Driver } from "neo4j-driver";
 import { authResolvers } from "../resolvers/auth";
+import { channelResolvers } from "../resolvers/channel";
 import { verifyToken } from "../services/jwt";
+import { channelTypesDefs } from "../types/channel";
 import { Context } from "../types/context";
 import { userTypeDefs } from "../types/user";
 
@@ -19,8 +21,8 @@ const baseTypeDefs = `#graphql
 
 export const createApolloServer = () => {
   return new ApolloServer<Context>({
-    typeDefs: [baseTypeDefs, userTypeDefs],
-    resolvers: [authResolvers],
+    typeDefs: [baseTypeDefs, userTypeDefs, channelTypesDefs],
+    resolvers: [authResolvers, channelResolvers],
   });
 };
 

--- a/src/queries/channel.ts
+++ b/src/queries/channel.ts
@@ -64,4 +64,19 @@ export const channelQueries = {
     } as channel
     ORDER BY c.createdAt DESC
   `,
+
+  updateChannel: `
+    MATCH (u:User)-[:CREATED]->(c:Channel {id: $channelId})
+    SET c.name = $name, c.description = $description
+    RETURN c
+  `,
+
+  deleteChannel: `
+    MATCH (c:Channel {id: $channelId})
+    WITH c
+    OPTIONAL MATCH (c)-[r]-() // delete all relationships related to the channel
+    WITH c, r
+    DELETE r, c
+    RETURN true as success
+  `,
 };

--- a/src/queries/channel.ts
+++ b/src/queries/channel.ts
@@ -1,0 +1,14 @@
+export const channelQueries = {
+  createChannel: `
+    CREATE (c:Channel {
+      id: $channelId,
+      name: $name,
+      description: $description,
+      createdAt: $now
+    })
+    WITH c
+    MATCH (u:User {id: $createdBy})
+    CREATE (u)-[:CREATED]->(c)
+    RETURN c
+  `,
+};

--- a/src/queries/channel.ts
+++ b/src/queries/channel.ts
@@ -3,7 +3,7 @@ export const channelQueries = {
     CREATE (c:Channel {
       id: $channelId,
       name: $name,
-      description: $description,
+      description: CASE WHEN $description IS NOT NULL THEN $description END,
       createdAt: $now
     })
     WITH c
@@ -67,11 +67,14 @@ export const channelQueries = {
 
   updateChannel: `
     MATCH (u:User)-[:CREATED]->(c:Channel {id: $channelId})
-    SET c.name = $name, c.description = $description
+    SET c += {
+      name: CASE WHEN $name IS NOT NULL THEN $name ELSE c.name END,
+      description: CASE WHEN $description IS NOT NULL THEN $description ELSE c.description END
+    }
     RETURN c
   `,
 
-  deleteChannel: `
+  deleteChannel: `    
     MATCH (c:Channel {id: $channelId})
     WITH c
     OPTIONAL MATCH (c)-[r]-() // delete all relationships related to the channel

--- a/src/queries/channel.ts
+++ b/src/queries/channel.ts
@@ -4,7 +4,8 @@ export const channelQueries = {
       id: $channelId,
       name: $name,
       description: CASE WHEN $description IS NOT NULL THEN $description END,
-      createdAt: $now
+      createdAt: $now,
+      updatedAt: $now
     })
     WITH c
     MATCH (u:User {id: $createdBy})
@@ -69,7 +70,8 @@ export const channelQueries = {
     MATCH (u:User)-[:CREATED]->(c:Channel {id: $channelId})
     SET c += {
       name: CASE WHEN $name IS NOT NULL THEN $name ELSE c.name END,
-      description: CASE WHEN $description IS NOT NULL THEN $description ELSE c.description END
+      description: CASE WHEN $description IS NOT NULL THEN $description ELSE c.description END,
+      updatedAt: $updatedAt
     }
     RETURN c
   `,

--- a/src/queries/channel.ts
+++ b/src/queries/channel.ts
@@ -11,4 +11,57 @@ export const channelQueries = {
     CREATE (u)-[:CREATED]->(c)
     RETURN c
   `,
+
+  findChannelById: `
+    MATCH (u:User)-[:CREATED]->(c:Channel {id: $channelId})
+    RETURN {
+      id: c.id,
+      name: c.name,
+      description: c.description,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        createdAt: u.createdAt
+      }
+    } as channel
+  `,
+
+  findMyChannels: `
+    MATCH (u:User {id: $userId})-[:CREATED]->(c:Channel)
+    RETURN {
+      id: c.id,
+      name: c.name,
+      description: c.description,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        email: u.email,
+        role: u.role,
+        createdAt: u.createdAt,
+        updatedAt: u.updatedAt
+      }
+    } as channel
+    ORDER BY c.createdAt DESC
+  `,
+
+  findChannelsByUserId: `
+    MATCH (u:User {id: $userId})-[:CREATED]->(c:Channel)
+    RETURN {
+      id: c.id,
+      name: c.name,
+      description: c.description,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        createdAt: u.createdAt
+      }
+    } as channel
+    ORDER BY c.createdAt DESC
+  `,
 };

--- a/src/resolvers/channel.ts
+++ b/src/resolvers/channel.ts
@@ -1,0 +1,26 @@
+import { ChannelService } from "../services/channel";
+import { CreateChannelInput } from "../types/channel";
+import { Context } from "../types/context";
+import { UserRole } from "../types/user";
+
+export const channelResolvers = {
+  Mutation: {
+    createChannel: async (
+      _: any,
+      { input }: { input: CreateChannelInput },
+      { driver, user }: Context
+    ) => {
+      if (!user) throw new Error("Not authenticated");
+
+      if (user.role !== UserRole.CREATOR) {
+        throw new Error("User is not a creator");
+      }
+
+      const channelService = new ChannelService(driver);
+      return channelService.createChannel({
+        ...input,
+        createdBy: user.userId,
+      });
+    },
+  },
+};

--- a/src/resolvers/channel.ts
+++ b/src/resolvers/channel.ts
@@ -23,4 +23,35 @@ export const channelResolvers = {
       });
     },
   },
+
+  Query: {
+    findMyChannels: async (_: any, __: any, { driver, user }: Context) => {
+      if (!user) throw new Error("Not authenticated");
+
+      const channelService = new ChannelService(driver);
+      return channelService.findMyChannels(user.userId);
+    },
+
+    findChannelById: async (
+      _: any,
+      { input }: { input: { channelId: string } },
+      { driver }: Context
+    ) => {
+      const channelService = new ChannelService(driver);
+      const channel = await channelService.findChannelById(input.channelId);
+
+      if (!channel) throw new Error("Channel not found");
+
+      return channel;
+    },
+
+    findChannelsByUserId: async (
+      _: any,
+      { input }: { input: { userId: string } },
+      { driver }: Context
+    ) => {
+      const channelService = new ChannelService(driver);
+      return channelService.findChannelsByUserId(input.userId);
+    },
+  },
 };

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -29,4 +29,44 @@ export class ChannelService {
       await session.close();
     }
   }
+
+  async findChannelById(channelId: string): Promise<Channel | null> {
+    const session = this.driver.session();
+    try {
+      const result = await session.run(channelQueries.findChannelById, {
+        channelId,
+      });
+
+      const record = result.records[0];
+      return record ? record.get("channel") : null;
+    } finally {
+      await session.close();
+    }
+  }
+
+  async findMyChannels(userId: string): Promise<Channel[]> {
+    const session = this.driver.session();
+    try {
+      const result = await session.run(channelQueries.findMyChannels, {
+        userId,
+      });
+
+      return result.records.map((record) => record.get("channel")) || [];
+    } finally {
+      await session.close();
+    }
+  }
+
+  async findChannelsByUserId(userId: string): Promise<Channel[]> {
+    const session = this.driver.session();
+    try {
+      const result = await session.run(channelQueries.findChannelsByUserId, {
+        userId,
+      });
+
+      return result.records.map((record) => record.get("channel")) || [];
+    } finally {
+      await session.close();
+    }
+  }
 }

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -23,7 +23,7 @@ export class ChannelService {
       const result = await session.run(channelQueries.createChannel, {
         channelId,
         name: input.name,
-        description: input.description,
+        description: input.description ?? null,
         createdBy: input.createdBy,
         now,
       });
@@ -79,8 +79,8 @@ export class ChannelService {
     try {
       const result = await session.run(channelQueries.updateChannel, {
         channelId: input.channelId,
-        name: input.name,
-        description: input.description,
+        name: input.name ?? null,
+        description: "description" in input ? input.description : null,
       });
 
       return result.records[0].get("c").properties as Channel;

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -1,7 +1,11 @@
 import { Driver } from "neo4j-driver";
 import { v4 as uuidv4 } from "uuid";
 import { channelQueries } from "../queries/channel";
-import { Channel, CreateChannelInput } from "../types/channel";
+import {
+  Channel,
+  CreateChannelInput,
+  UpdateChannelInput,
+} from "../types/channel";
 
 interface CreateChannelData extends CreateChannelInput {
   createdBy: string;
@@ -65,6 +69,34 @@ export class ChannelService {
       });
 
       return result.records.map((record) => record.get("channel")) || [];
+    } finally {
+      await session.close();
+    }
+  }
+
+  async updateChannel(input: UpdateChannelInput): Promise<Channel> {
+    const session = this.driver.session();
+    try {
+      const result = await session.run(channelQueries.updateChannel, {
+        channelId: input.channelId,
+        name: input.name,
+        description: input.description,
+      });
+
+      return result.records[0].get("c").properties as Channel;
+    } finally {
+      await session.close();
+    }
+  }
+
+  async deleteChannel(channelId: string): Promise<boolean> {
+    const session = this.driver.session();
+    try {
+      const result = await session.run(channelQueries.deleteChannel, {
+        channelId,
+      });
+
+      return result.records[0]?.get("success") || false;
     } finally {
       await session.close();
     }

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -76,11 +76,13 @@ export class ChannelService {
 
   async updateChannel(input: UpdateChannelInput): Promise<Channel> {
     const session = this.driver.session();
+    const now = new Date().toISOString();
     try {
       const result = await session.run(channelQueries.updateChannel, {
         channelId: input.channelId,
         name: input.name ?? null,
-        description: "description" in input ? input.description : null,
+        description: input.description ?? null,
+        updatedAt: now,
       });
 
       return result.records[0].get("c").properties as Channel;

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -1,0 +1,32 @@
+import { Driver } from "neo4j-driver";
+import { v4 as uuidv4 } from "uuid";
+import { channelQueries } from "../queries/channel";
+import { Channel, CreateChannelInput } from "../types/channel";
+
+interface CreateChannelData extends CreateChannelInput {
+  createdBy: string;
+}
+
+export class ChannelService {
+  constructor(private readonly driver: Driver) {}
+
+  async createChannel(input: CreateChannelData): Promise<Channel> {
+    const session = this.driver.session();
+    try {
+      const channelId = uuidv4();
+      const now = new Date().toISOString();
+
+      const result = await session.run(channelQueries.createChannel, {
+        channelId,
+        name: input.name,
+        description: input.description,
+        createdBy: input.createdBy,
+        now,
+      });
+
+      return result.records[0].get("c").properties as Channel;
+    } finally {
+      await session.close();
+    }
+  }
+}

--- a/src/services/jwt.ts
+++ b/src/services/jwt.ts
@@ -1,8 +1,9 @@
 import jwt from "jsonwebtoken";
+import ms from "ms";
 import { User, UserRole } from "../types/user";
 
 const JWT_SECRET = process.env.JWT_SECRET;
-const JWT_EXPIRES_IN: number = parseInt(process.env.JWT_EXPIRES_IN || "5m");
+const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "5m";
 
 export interface TokenPayload {
   userId: string;
@@ -19,7 +20,9 @@ export const generateToken = (user: User): string => {
     role: user.role,
   };
 
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
+  return jwt.sign(payload, JWT_SECRET, {
+    expiresIn: JWT_EXPIRES_IN as ms.StringValue,
+  });
 };
 
 export const verifyToken = (token: string): TokenPayload => {

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -1,0 +1,33 @@
+export interface Channel {
+  id: string;
+  name: string;
+  description: string;
+  createdBy: string; // user id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateChannelInput {
+  name: string;
+  description: string;
+}
+
+export const channelTypesDefs = `
+  type Channel {
+    id: ID!
+    name: String!
+    description: String!
+    createdBy: String!
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  input CreateChannelInput {
+    name: String!
+    description: String!
+  }
+
+  type Mutation {
+    createChannel(input: CreateChannelInput!): Channel
+  }
+`;

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -1,25 +1,24 @@
 import { User } from "./user";
 
-export interface Channel {
-  id: string;
+export interface CreateChannelInput {
   name: string;
-  description: string;
+  description?: string | null;
+}
+
+export interface Channel extends CreateChannelInput {
+  id: string;
   createdAt: string;
   updatedAt: string;
   createdBy: User;
 }
 
-export interface CreateChannelInput {
-  name: string;
-  description: string;
-}
-
-export interface UpdateChannelInput extends CreateChannelInput {
-  channelId: string;
-}
-
 export interface DeleteChannelInput {
   channelId: string;
+}
+
+export interface UpdateChannelInput extends DeleteChannelInput {
+  name?: string;
+  description?: string;
 }
 
 export const channelTypesDefs = `
@@ -43,7 +42,7 @@ export const channelTypesDefs = `
   type Channel {
     id: ID!
     name: String!
-    description: String!
+    description: String
     createdAt: String!
     updatedAt: String!
   }
@@ -51,7 +50,7 @@ export const channelTypesDefs = `
   type MyChannel {
     id: ID!
     name: String!
-    description: String!
+    description: String
     createdAt: String!
     updatedAt: String!
     createdBy: ChannelCreatorFull!
@@ -60,7 +59,7 @@ export const channelTypesDefs = `
   type PublicChannel {
     id: ID!
     name: String!
-    description: String!
+    description: String
     createdAt: String!
     updatedAt: String!
     createdBy: ChannelCreatorLimited!
@@ -68,7 +67,7 @@ export const channelTypesDefs = `
 
   input CreateChannelInput {
     name: String!
-    description: String!
+    description: String
   }
 
   input FindChannelByIdInput {

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -1,10 +1,12 @@
+import { User } from "./user";
+
 export interface Channel {
   id: string;
   name: string;
   description: string;
-  createdBy: string; // user id
   createdAt: string;
   updatedAt: string;
+  createdBy: User;
 }
 
 export interface CreateChannelInput {
@@ -13,18 +15,66 @@ export interface CreateChannelInput {
 }
 
 export const channelTypesDefs = `
+  # for authenticated user's own data
+  type ChannelCreatorFull {
+    id: ID!
+    username: String!
+    email: String!
+    role: UserRole!
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  # for public viewing, hide email
+  type ChannelCreatorLimited {
+    id: ID!
+    username: String!
+    createdAt: String!
+  }
+
   type Channel {
     id: ID!
     name: String!
     description: String!
-    createdBy: String!
     createdAt: String!
     updatedAt: String!
+  }
+
+  type MyChannel {
+    id: ID!
+    name: String!
+    description: String!
+    createdAt: String!
+    updatedAt: String!
+    createdBy: ChannelCreatorFull!
+  }
+
+  type PublicChannel {
+    id: ID!
+    name: String!
+    description: String!
+    createdAt: String!
+    updatedAt: String!
+    createdBy: ChannelCreatorLimited!
   }
 
   input CreateChannelInput {
     name: String!
     description: String!
+  }
+
+  input FindChannelByIdInput {
+    channelId: String!
+  }
+
+  input FindChannelsByUserIdInput {
+    userId: String!
+  }
+
+  type Query {
+    findMyChannels: [MyChannel!]!
+    findChannelById(input: FindChannelByIdInput!): PublicChannel
+    findChannelsByUserId(input: FindChannelsByUserIdInput!): [PublicChannel!]!
   }
 
   type Mutation {

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -14,6 +14,14 @@ export interface CreateChannelInput {
   description: string;
 }
 
+export interface UpdateChannelInput extends CreateChannelInput {
+  channelId: string;
+}
+
+export interface DeleteChannelInput {
+  channelId: string;
+}
+
 export const channelTypesDefs = `
   # for authenticated user's own data
   type ChannelCreatorFull {
@@ -71,13 +79,30 @@ export const channelTypesDefs = `
     userId: String!
   }
 
+  input UpdateChannelInput {
+    channelId: String!
+    name: String
+    description: String
+  }
+
+  input DeleteChannelInput {
+    channelId: String!
+  }
+
   type Query {
     findMyChannels: [MyChannel!]!
     findChannelById(input: FindChannelByIdInput!): PublicChannel
     findChannelsByUserId(input: FindChannelsByUserIdInput!): [PublicChannel!]!
   }
 
+  type DeleteChannelResponse {
+    success: Boolean!
+    message: String!
+  }
+
   type Mutation {
     createChannel(input: CreateChannelInput!): Channel
+    updateChannel(input: UpdateChannelInput!): Channel
+    deleteChannel(input: DeleteChannelInput!): DeleteChannelResponse!
   }
 `;


### PR DESCRIPTION
Implement management operations for channels

closes #2

## Features
- CRUD operations for channels
- Role-based channel creation (CREATOR role required)
- Owner-based channel modifications
- Channel data exposure based on owndership: do not expose sensitive data, like user `email` to other users

## Technical Details

### Core Functionality
1. Channel Creation
   - Required name, optional description
   - Automatic creator assignment
   - Role-based access control (CREATOR only)

2. Channel Retrieval
   - Find channel by ID for any user role
   - Get user's own channels using authorization header
   - List channels by user ID for any user role

3. Channel Updates
   - Partial updates (name/description can be ommited)
   - Owner-only modification

4. Channel Deletion
   - Owner verification
   - Safe node removal: it deletes relationships as well