### PR TITLE
feat: add Block entities and CRUD operations

### DIFF
--- a/src/config/apollo.ts
+++ b/src/config/apollo.ts
@@ -3,8 +3,10 @@ import { expressMiddleware } from "@apollo/server/express4";
 import { Express } from "express";
 import { Driver } from "neo4j-driver";
 import { authResolvers } from "../resolvers/auth";
+import { blockResolvers } from "../resolvers/block";
 import { channelResolvers } from "../resolvers/channel";
 import { verifyToken } from "../services/jwt";
+import { blockTypeDefs } from "../types/block";
 import { channelTypesDefs } from "../types/channel";
 import { Context } from "../types/context";
 import { userTypeDefs } from "../types/user";
@@ -21,8 +23,8 @@ const baseTypeDefs = `#graphql
 
 export const createApolloServer = () => {
   return new ApolloServer<Context>({
-    typeDefs: [baseTypeDefs, userTypeDefs, channelTypesDefs],
-    resolvers: [authResolvers, channelResolvers],
+    typeDefs: [baseTypeDefs, userTypeDefs, channelTypesDefs, blockTypeDefs],
+    resolvers: [authResolvers, channelResolvers, blockResolvers],
   });
 };
 

--- a/src/queries/block.ts
+++ b/src/queries/block.ts
@@ -1,0 +1,83 @@
+export const blockQueries = {
+  createBlock: `
+    MATCH (ch:Channel {id: $channelId})
+    CREATE (b:Block {
+      id: $blockId,
+      title: CASE WHEN $title IS NOT NULL THEN $title END,
+      description: CASE WHEN $description IS NOT NULL THEN $description END,
+      content: $content,
+      createdAt: $now,
+      updatedAt: $now
+    })
+    WITH b, ch
+    MATCH (u:User {id: $createdBy})
+    CREATE (u)-[:CREATED]->(b)
+    CREATE (b)-[:CONNECTED_TO]->(ch)
+    RETURN {
+      id: b.id,
+      title: b.title,
+      description: b.description,
+      content: b.content,
+      createdAt: b.createdAt,
+      updatedAt: b.updatedAt,
+      channel: {
+        id: ch.id,
+        name: ch.name,
+        description: ch.description
+      },
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        email: u.email,
+        role: u.role,
+        createdAt: u.createdAt,
+        updatedAt: u.updatedAt
+      }
+    } as block
+  `,
+
+  findBlockById: `
+    MATCH (u:User)-[:CREATED]->(b:Block {id: $blockId})-[:CONNECTED_TO]->(ch:Channel)
+    RETURN {
+      id: b.id,
+      title: b.title,
+      description: b.description,
+      content: b.content,
+      createdAt: b.createdAt,
+      updatedAt: b.updatedAt,
+      channel: {
+        id: ch.id,
+        name: ch.name,
+        description: ch.description
+      },
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        createdAt: u.createdAt
+      }
+    } as block
+  `,
+
+  findBlocksByChannelId: `
+    MATCH (u:User)-[:CREATED]->(b:Block)-[:CONNECTED_TO]->(ch:Channel {id: $channelId})
+    RETURN {
+      id: b.id,
+      title: b.title,
+      description: b.description,
+      content: b.content,
+      createdAt: b.createdAt,
+      updatedAt: b.updatedAt,
+      channel: {
+        id: ch.id,
+        name: ch.name,
+        description: ch.description
+      },
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        createdAt: u.createdAt
+      }
+    } as block
+    ORDER BY b.createdAt DESC
+  `,
+};

--- a/src/queries/block.ts
+++ b/src/queries/block.ts
@@ -80,4 +80,43 @@ export const blockQueries = {
     } as block
     ORDER BY b.createdAt DESC
   `,
+
+  updateBlock: `
+    MATCH (u:User)-[:CREATED]->(b:Block {id: $blockId})-[:CONNECTED_TO]->(ch:Channel)
+    SET b += {
+      title: CASE WHEN $title IS NOT NULL THEN $title ELSE b.title END,
+      description: CASE WHEN $description IS NOT NULL THEN $description END,
+      content: CASE WHEN $content IS NOT NULL THEN $content ELSE b.content END,
+      updatedAt: $updatedAt
+    }
+    RETURN {
+      id: b.id,
+      title: b.title,
+      description: b.description,
+      content: b.content,
+      createdAt: b.createdAt,
+      updatedAt: b.updatedAt,
+      channel: {
+        id: ch.id,
+        title: ch.title,
+        description: ch.description
+      },
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        email: u.email,
+        role: u.role,
+        createdAt: u.createdAt,
+        updatedAt: u.updatedAt
+      }
+    } as block
+  `,
+
+  deleteBlock: `
+    MATCH (b:Block {id: $blockId})
+    WITH b
+    OPTIONAL MATCH (b)-[r]-()
+    DELETE r, b
+    RETURN true as success
+  `,
 };

--- a/src/queries/block.ts
+++ b/src/queries/block.ts
@@ -119,4 +119,50 @@ export const blockQueries = {
     DELETE r, b
     RETURN true as success
   `,
+
+  connectBlockToChannel: `
+    MATCH (b:Block {id: $blockId})
+    MATCH (ch:Channel {id: $channelId})
+    MERGE (b)-[:CONNECTED_TO]->(ch)
+    WITH b, ch
+    MATCH (u:User)-[:CREATED]->(b)
+    RETURN {
+      id: b.id,
+      title: b.title,
+      description: b.description,
+      content: b.content,
+      createdAt: b.createdAt,
+      updatedAt: b.updatedAt,
+      channel: {
+        id: ch.id,
+        name: ch.name,
+        description: ch.description
+      },
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        email: u.email,
+        role: u.role,
+        createdAt: u.createdAt,
+        updatedAt: u.updatedAt
+      }
+    } as block
+  `,
+
+  findBlockConnections: `
+    MATCH (b:Block {id: $blockId})-[:CONNECTED_TO]->(ch:Channel)
+    MATCH (u:User)-[:CREATED]->(ch)
+    RETURN {
+      id: ch.id,
+      name: ch.name,
+      description: ch.description,
+      createdAt: ch.createdAt,
+      createdBy: {
+        id: u.id,
+        username: u.username,
+        createdAt: u.createdAt
+      }
+    } as connection
+    ORDER BY ch.createdAt DESC
+  `,
 };

--- a/src/queries/block.ts
+++ b/src/queries/block.ts
@@ -22,7 +22,7 @@ export const blockQueries = {
       updatedAt: b.updatedAt,
       channel: {
         id: ch.id,
-        name: ch.name,
+        title: ch.title,
         description: ch.description
       },
       createdBy: {
@@ -47,7 +47,7 @@ export const blockQueries = {
       updatedAt: b.updatedAt,
       channel: {
         id: ch.id,
-        name: ch.name,
+        title: ch.title,
         description: ch.description
       },
       createdBy: {
@@ -69,7 +69,7 @@ export const blockQueries = {
       updatedAt: b.updatedAt,
       channel: {
         id: ch.id,
-        name: ch.name,
+        title: ch.title,
         description: ch.description
       },
       createdBy: {

--- a/src/queries/block.ts
+++ b/src/queries/block.ts
@@ -135,7 +135,7 @@ export const blockQueries = {
       updatedAt: b.updatedAt,
       channel: {
         id: ch.id,
-        name: ch.name,
+        title: ch.title,
         description: ch.description
       },
       createdBy: {
@@ -154,7 +154,7 @@ export const blockQueries = {
     MATCH (u:User)-[:CREATED]->(ch)
     RETURN {
       id: ch.id,
-      name: ch.name,
+      title: ch.title,
       description: ch.description,
       createdAt: ch.createdAt,
       createdBy: {

--- a/src/queries/channel.ts
+++ b/src/queries/channel.ts
@@ -2,7 +2,7 @@ export const channelQueries = {
   createChannel: `
     CREATE (c:Channel {
       id: $channelId,
-      name: $name,
+      title: $title,
       description: CASE WHEN $description IS NOT NULL THEN $description END,
       createdAt: $now,
       updatedAt: $now
@@ -17,7 +17,7 @@ export const channelQueries = {
     MATCH (u:User)-[:CREATED]->(c:Channel {id: $channelId})
     RETURN {
       id: c.id,
-      name: c.name,
+      title: c.title,
       description: c.description,
       createdAt: c.createdAt,
       updatedAt: c.updatedAt,
@@ -33,7 +33,7 @@ export const channelQueries = {
     MATCH (u:User {id: $userId})-[:CREATED]->(c:Channel)
     RETURN {
       id: c.id,
-      name: c.name,
+      title: c.title,
       description: c.description,
       createdAt: c.createdAt,
       updatedAt: c.updatedAt,
@@ -53,7 +53,7 @@ export const channelQueries = {
     MATCH (u:User {id: $userId})-[:CREATED]->(c:Channel)
     RETURN {
       id: c.id,
-      name: c.name,
+      title: c.title,
       description: c.description,
       createdAt: c.createdAt,
       updatedAt: c.updatedAt,
@@ -69,7 +69,7 @@ export const channelQueries = {
   updateChannel: `
     MATCH (u:User)-[:CREATED]->(c:Channel {id: $channelId})
     SET c += {
-      name: CASE WHEN $name IS NOT NULL THEN $name ELSE c.name END,
+      title: CASE WHEN $title IS NOT NULL THEN $title ELSE c.title END,
       description: CASE WHEN $description IS NOT NULL THEN $description ELSE c.description END,
       updatedAt: $updatedAt
     }

--- a/src/queries/channel.ts
+++ b/src/queries/channel.ts
@@ -78,10 +78,18 @@ export const channelQueries = {
 
   deleteChannel: `    
     MATCH (c:Channel {id: $channelId})
+    
+    // delete all blocks connected to this channel
     WITH c
-    OPTIONAL MATCH (c)-[r]-() // delete all relationships related to the channel
-    WITH c, r
-    DELETE r, c
+    OPTIONAL MATCH (b:Block)-[r:CONNECTED_TO]->(c)
+    WITH c, b, r
+    OPTIONAL MATCH (b)-[br]-()
+    DELETE br, b
+    
+    WITH c
+    OPTIONAL MATCH (c)-[cr]-()
+    DELETE cr, c
+    
     RETURN true as success
   `,
 };

--- a/src/resolvers/block.ts
+++ b/src/resolvers/block.ts
@@ -5,11 +5,7 @@ import { UserRole } from "../types/user";
 
 export const blockResolvers = {
   Query: {
-    findBlockById: async (
-      _: any,
-      { id }: { id: string },
-      { driver }: Context
-    ) => {
+    block: async (_: any, { id }: { id: string }, { driver }: Context) => {
       const blockService = new BlockService(driver);
       const block = await blockService.findBlockById(id);
 
@@ -18,7 +14,7 @@ export const blockResolvers = {
       return block;
     },
 
-    findBlocksByChannelId: async (
+    blocksByChannelId: async (
       _: any,
       { channelId }: { channelId: string },
       { driver }: Context

--- a/src/resolvers/block.ts
+++ b/src/resolvers/block.ts
@@ -1,0 +1,50 @@
+import { BlockService } from "../services/block";
+import { CreateBlockInput } from "../types/block";
+import { Context } from "../types/context";
+import { UserRole } from "../types/user";
+
+export const blockResolvers = {
+  Query: {
+    findBlockById: async (
+      _: any,
+      { id }: { id: string },
+      { driver }: Context
+    ) => {
+      const blockService = new BlockService(driver);
+      const block = await blockService.findBlockById(id);
+
+      if (!block) throw new Error("Block not found");
+
+      return block;
+    },
+
+    findBlocksByChannelId: async (
+      _: any,
+      { channelId }: { channelId: string },
+      { driver }: Context
+    ) => {
+      const blockService = new BlockService(driver);
+      return blockService.findBlocksByChannelId(channelId);
+    },
+  },
+
+  Mutation: {
+    createBlock: async (
+      _: any,
+      { input }: { input: CreateBlockInput },
+      { driver, user }: Context
+    ) => {
+      if (!user) throw new Error("Not authenticated");
+
+      if (user.role !== UserRole.CREATOR) {
+        throw new Error("User is not a creator");
+      }
+
+      const blockService = new BlockService(driver);
+      return blockService.createBlock({
+        ...input,
+        createdBy: user.userId,
+      });
+    },
+  },
+};

--- a/src/resolvers/block.ts
+++ b/src/resolvers/block.ts
@@ -1,5 +1,9 @@
 import { BlockService } from "../services/block";
-import { CreateBlockInput } from "../types/block";
+import {
+  CreateBlockInput,
+  DeleteBlockInput,
+  UpdateBlockInput,
+} from "../types/block";
 import { Context } from "../types/context";
 import { UserRole } from "../types/user";
 
@@ -41,6 +45,53 @@ export const blockResolvers = {
         ...input,
         createdBy: user.userId,
       });
+    },
+
+    updateBlock: async (
+      _: any,
+      { input }: { input: UpdateBlockInput },
+      { driver, user }: Context
+    ) => {
+      if (!user) throw new Error("Not authenticated");
+
+      const blockService = new BlockService(driver);
+      const block = await blockService.findBlockById(input.blockId);
+
+      if (!block) throw new Error("Block not found");
+
+      if (block.createdBy.id !== user.userId) {
+        throw new Error("User is not the creator of the block");
+      }
+
+      return blockService.updateBlock(input);
+    },
+
+    deleteBlock: async (
+      _: any,
+      { input }: { input: DeleteBlockInput },
+      { driver, user }: Context
+    ) => {
+      if (!user) throw new Error("Not authenticated");
+
+      const blockService = new BlockService(driver);
+      const block = await blockService.findBlockById(input.blockId);
+
+      if (!block) throw new Error("Block not found");
+
+      if (block.createdBy.id !== user.userId) {
+        throw new Error("User is not the creator of the block");
+      }
+
+      const success = await blockService.deleteBlock(input.blockId);
+
+      if (!success) {
+        throw new Error("Failed to delete block");
+      }
+
+      return {
+        success: true,
+        message: "Block successfully deleted",
+      };
     },
   },
 };

--- a/src/resolvers/channel.ts
+++ b/src/resolvers/channel.ts
@@ -9,7 +9,7 @@ import { UserRole } from "../types/user";
 
 export const channelResolvers = {
   Query: {
-    findChannelById: async (
+    channel: async (
       _: any,
       { input }: { input: { channelId: string } },
       { driver }: Context
@@ -22,14 +22,14 @@ export const channelResolvers = {
       return channel;
     },
 
-    findMyChannels: async (_: any, __: any, { driver, user }: Context) => {
+    myChannels: async (_: any, __: any, { driver, user }: Context) => {
       if (!user) throw new Error("Not authenticated");
 
       const channelService = new ChannelService(driver);
       return channelService.findMyChannels(user.userId);
     },
 
-    findChannelsByUserId: async (
+    channelsByUserId: async (
       _: any,
       { input }: { input: { userId: string } },
       { driver }: Context

--- a/src/resolvers/channel.ts
+++ b/src/resolvers/channel.ts
@@ -85,6 +85,7 @@ export const channelResolvers = {
       if (!user) throw new Error("Not authenticated");
 
       const channelService = new ChannelService(driver);
+
       const channel = await channelService.findChannelById(input.channelId);
       if (!channel) throw new Error("Channel not found");
 
@@ -93,7 +94,6 @@ export const channelResolvers = {
       }
 
       const success = await channelService.deleteChannel(input.channelId);
-
       if (!success) {
         throw new Error("Failed to delete channel");
       }

--- a/src/services/block.ts
+++ b/src/services/block.ts
@@ -1,0 +1,73 @@
+import { Driver } from "neo4j-driver";
+import { v4 as uuidv4 } from "uuid";
+import { blockQueries } from "../queries/block";
+import { Block, CreateBlockInput } from "../types/block";
+
+interface CreateBlockData extends CreateBlockInput {
+  createdBy: string;
+}
+
+export class BlockService {
+  private driver: Driver;
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  async createBlock(data: CreateBlockData): Promise<Block> {
+    const session = this.driver.session();
+
+    try {
+      const now = new Date().toISOString();
+      const blockId = uuidv4();
+
+      const result = await session.executeWrite((tx) =>
+        tx.run(blockQueries.createBlock, {
+          blockId,
+          channelId: data.channelId,
+          title: data.title ?? null,
+          description: data.description ?? null,
+          content: data.content,
+          createdBy: data.createdBy,
+          now,
+        })
+      );
+
+      const block = result.records[0]?.get("block");
+      if (!block) throw new Error("Failed to create block");
+
+      return block;
+    } finally {
+      await session.close();
+    }
+  }
+
+  async findBlockById(blockId: string): Promise<Block | null> {
+    const session = this.driver.session();
+
+    try {
+      const result = await session.executeRead((tx) =>
+        tx.run(blockQueries.findBlockById, { blockId })
+      );
+
+      const block = result.records[0]?.get("block");
+      return block || null;
+    } finally {
+      await session.close();
+    }
+  }
+
+  async findBlocksByChannelId(channelId: string): Promise<Block[]> {
+    const session = this.driver.session();
+
+    try {
+      const result = await session.executeRead((tx) =>
+        tx.run(blockQueries.findBlocksByChannelId, { channelId })
+      );
+
+      return result.records.map((record) => record.get("block"));
+    } finally {
+      await session.close();
+    }
+  }
+}

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -22,7 +22,7 @@ export class ChannelService {
 
       const result = await session.run(channelQueries.createChannel, {
         channelId,
-        name: input.name,
+        title: input.title,
         description: input.description ?? null,
         createdBy: input.createdBy,
         now,
@@ -80,7 +80,7 @@ export class ChannelService {
     try {
       const result = await session.run(channelQueries.updateChannel, {
         channelId: input.channelId,
-        name: input.name ?? null,
+        title: input.title ?? null,
         description: input.description ?? null,
         updatedAt: now,
       });

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -1,4 +1,4 @@
-import { Driver } from "neo4j-driver";
+import { Driver, Integer } from "neo4j-driver";
 import { v4 as uuidv4 } from "uuid";
 import { channelQueries } from "../queries/channel";
 import {
@@ -91,14 +91,47 @@ export class ChannelService {
     }
   }
 
+  async getChannelBlocksInfo(channelId: string): Promise<{
+    channelId: string;
+    channelCreatorId: string;
+    blocks: Array<{
+      blockId: string;
+      blockCreatorId: string;
+      connectionCount: number;
+    }>;
+  } | null> {
+    const session = this.driver.session();
+    try {
+      const result = await session.executeRead((tx) =>
+        tx.run(channelQueries.getChannelBlocksInfo, { channelId })
+      );
+      const info = result.records[0]?.get("info");
+      if (!info) return null;
+
+      return {
+        ...info,
+        blocks: info.blocks.map((block: { connectionCount: Integer }) => ({
+          ...block,
+          connectionCount: (block.connectionCount as Integer).toNumber(),
+        })),
+      };
+    } finally {
+      await session.close();
+    }
+  }
+
   async deleteChannel(channelId: string): Promise<boolean> {
     const session = this.driver.session();
     try {
-      const result = await session.run(channelQueries.deleteChannel, {
-        channelId,
-      });
+      await session.executeWrite((tx) =>
+        tx.run(channelQueries.deleteChannelBlocks, { channelId })
+      );
 
-      return result.records[0]?.get("success") || false;
+      const result = await session.executeWrite((tx) =>
+        tx.run(channelQueries.deleteChannel, { channelId })
+      );
+
+      return result.records[0]?.get("success") ?? false;
     } finally {
       await session.close();
     }

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -15,6 +15,16 @@ export interface Block extends CreateBlockInput {
   createdBy: User;
 }
 
+export interface DeleteBlockInput {
+  blockId: string;
+}
+
+export interface UpdateBlockInput extends DeleteBlockInput {
+  title?: string;
+  description?: string;
+  content?: string;
+}
+
 export const blockTypeDefs = gql`
   type BlockCreatorFull {
     id: ID!
@@ -60,6 +70,22 @@ export const blockTypeDefs = gql`
     channelId: String!
   }
 
+  input UpdateBlockInput {
+    blockId: String!
+    title: String
+    description: String
+    content: String
+  }
+
+  input DeleteBlockInput {
+    blockId: String!
+  }
+
+  type DeleteBlockResponse {
+    success: Boolean!
+    message: String!
+  }
+
   extend type Query {
     block(id: ID!): Block
     blocksByChannelId(channelId: ID!): [Block!]!
@@ -67,5 +93,7 @@ export const blockTypeDefs = gql`
 
   extend type Mutation {
     createBlock(input: CreateBlockInput!): MyBlock!
+    updateBlock(input: UpdateBlockInput!): MyBlock!
+    deleteBlock(input: DeleteBlockInput!): DeleteBlockResponse!
   }
 `;

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -1,0 +1,75 @@
+import { gql } from "graphql-tag";
+import { User } from "./user";
+
+export interface Block {
+  id: string;
+  channelId: string;
+  content: string;
+  title?: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: User;
+}
+
+export interface CreateBlockInput {
+  channelId: string;
+  content: string;
+  title?: string;
+  description?: string;
+}
+
+export const blockTypeDefs = gql`
+  type BlockCreatorFull {
+    id: ID!
+    username: String!
+    email: String!
+    role: UserRole!
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  type BlockCreatorLimited {
+    id: ID!
+    username: String!
+    createdAt: String!
+  }
+
+  type Block {
+    id: ID!
+    title: String
+    description: String
+    content: String!
+    channel: Channel!
+    createdAt: String!
+    updatedAt: String!
+    createdBy: BlockCreatorLimited!
+  }
+
+  type MyBlock {
+    id: ID!
+    title: String
+    description: String
+    content: String!
+    channel: Channel!
+    createdAt: String!
+    updatedAt: String!
+    createdBy: BlockCreatorFull!
+  }
+
+  input CreateBlockInput {
+    title: String
+    description: String
+    content: String!
+    channelId: String!
+  }
+
+  extend type Query {
+    findBlockById(id: ID!): Block
+    findBlocksByChannelId(channelId: ID!): [Block!]!
+  }
+
+  extend type Mutation {
+    createBlock(input: CreateBlockInput!): MyBlock!
+  }
+`;

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -15,19 +15,15 @@ export interface Block extends CreateBlockInput {
   createdBy: User;
 }
 
-export interface DeleteBlockInput {
-  blockId: string;
-}
-
-export interface UpdateBlockInput extends DeleteBlockInput {
-  title?: string;
-  description?: string;
-  content?: string;
-}
-
 export interface BlockConnection {
   blockId: string;
   channelId: string;
+}
+
+export interface UpdateBlockInput extends BlockConnection {
+  title?: string;
+  description?: string;
+  content?: string;
 }
 
 export const blockTypeDefs = gql`
@@ -82,11 +78,7 @@ export const blockTypeDefs = gql`
     content: String
   }
 
-  input DeleteBlockInput {
-    blockId: String!
-  }
-
-  input ConnectBlockToChannelInput {
+  input BlockConnection {
     blockId: String!
     channelId: String!
   }
@@ -113,7 +105,7 @@ export const blockTypeDefs = gql`
   extend type Mutation {
     createBlock(input: CreateBlockInput!): MyBlock!
     updateBlock(input: UpdateBlockInput!): MyBlock!
-    deleteBlock(input: DeleteBlockInput!): DeleteBlockResponse!
-    connectBlockToChannel(input: ConnectBlockToChannelInput!): MyBlock!
+    deleteBlock(input: BlockConnection!): DeleteBlockResponse!
+    connectBlockToChannel(input: BlockConnection!): MyBlock!
   }
 `;

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -25,6 +25,11 @@ export interface UpdateBlockInput extends DeleteBlockInput {
   content?: string;
 }
 
+export interface BlockConnection {
+  blockId: string;
+  channelId: string;
+}
+
 export const blockTypeDefs = gql`
   type BlockCreatorFull {
     id: ID!
@@ -81,19 +86,34 @@ export const blockTypeDefs = gql`
     blockId: String!
   }
 
+  input ConnectBlockToChannelInput {
+    blockId: String!
+    channelId: String!
+  }
+
   type DeleteBlockResponse {
     success: Boolean!
     message: String!
   }
 
+  type ConnectedChannel {
+    id: ID!
+    name: String!
+    description: String
+    createdAt: String!
+    createdBy: BlockCreatorLimited!
+  }
+
   extend type Query {
     block(id: ID!): Block
     blocksByChannelId(channelId: ID!): [Block!]!
+    connectedChannels(blockId: ID!): [ConnectedChannel!]!
   }
 
   extend type Mutation {
     createBlock(input: CreateBlockInput!): MyBlock!
     updateBlock(input: UpdateBlockInput!): MyBlock!
     deleteBlock(input: DeleteBlockInput!): DeleteBlockResponse!
+    connectBlockToChannel(input: ConnectBlockToChannelInput!): MyBlock!
   }
 `;

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -1,22 +1,18 @@
 import { gql } from "graphql-tag";
 import { User } from "./user";
 
-export interface Block {
-  id: string;
-  channelId: string;
-  content: string;
-  title?: string;
-  description?: string;
-  createdAt: string;
-  updatedAt: string;
-  createdBy: User;
-}
-
 export interface CreateBlockInput {
   channelId: string;
   content: string;
   title?: string;
   description?: string;
+}
+
+export interface Block extends CreateBlockInput {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: User;
 }
 
 export const blockTypeDefs = gql`
@@ -65,8 +61,8 @@ export const blockTypeDefs = gql`
   }
 
   extend type Query {
-    findBlockById(id: ID!): Block
-    findBlocksByChannelId(channelId: ID!): [Block!]!
+    block(id: ID!): Block
+    blocksByChannelId(channelId: ID!): [Block!]!
   }
 
   extend type Mutation {

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -1,7 +1,7 @@
 import { User } from "./user";
 
 export interface CreateChannelInput {
-  name: string;
+  title: string;
   description?: string | null;
 }
 
@@ -17,7 +17,7 @@ export interface DeleteChannelInput {
 }
 
 export interface UpdateChannelInput extends DeleteChannelInput {
-  name?: string;
+  title?: string;
   description?: string;
 }
 
@@ -41,7 +41,7 @@ export const channelTypesDefs = `
 
   type Channel {
     id: ID!
-    name: String!
+    title: String!
     description: String
     createdAt: String!
     updatedAt: String!
@@ -49,7 +49,7 @@ export const channelTypesDefs = `
 
   type MyChannel {
     id: ID!
-    name: String!
+    title: String!
     description: String
     createdAt: String!
     updatedAt: String!
@@ -58,7 +58,7 @@ export const channelTypesDefs = `
 
   type PublicChannel {
     id: ID!
-    name: String!
+    title: String!
     description: String
     createdAt: String!
     updatedAt: String!
@@ -66,7 +66,7 @@ export const channelTypesDefs = `
   }
 
   input CreateChannelInput {
-    name: String!
+    title: String!
     description: String
   }
 
@@ -80,7 +80,7 @@ export const channelTypesDefs = `
 
   input UpdateChannelInput {
     channelId: String!
-    name: String
+    title: String
     description: String
   }
 
@@ -89,9 +89,9 @@ export const channelTypesDefs = `
   }
 
   type Query {
-    findMyChannels: [MyChannel!]!
-    findChannelById(input: FindChannelByIdInput!): PublicChannel
-    findChannelsByUserId(input: FindChannelsByUserIdInput!): [PublicChannel!]!
+    myChannels: [MyChannel!]!
+    channel(input: FindChannelByIdInput!): PublicChannel
+    channelsByUserId(input: FindChannelsByUserIdInput!): [PublicChannel!]!
   }
 
   type DeleteChannelResponse {


### PR DESCRIPTION
Added Block entities, CRUD operations and connections to channels

closes #3 

## Features

### 1. Block CRUD operations
- Implemented block creation
- Introduce creator & channel relationships
- Added queries to fetch blocks by ID, by channel
- Added ability to modify block with ownership validation
- Implemented smart deletion logic

### 2. Smart block deletion logic
1. **Creator deleting single-connection block**
   - Full deletion of block and relationships

2. **Creator deleting multi-connection block** or **Non-creator removing block from their channel**
   - Removes only the specific channel connection
   - Maintains block data and other connections

### 3. Channel deletion impact on blocks
Updated the logic for channel deletion to handle the blocks they have connections with:

1. **Block analysis**
   - For blocks with single connection (only to this channel): complete deletion of block and all relationships
   - For blocks with multiple connections: remove only the connection to this channel while maintaining block data and its other connections

2. **Cleanup**
   - Removes the channel itself
   - Cleans up any remaining channel relationships